### PR TITLE
Fix the Influxdb repo for "hybrid" debian distros (like "jessie/sid")

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -13,6 +13,7 @@
     name: "apt-transport-https"
     state: present
   when: not apt_https_transport.stat.exists
+  become: yes
   tags:
     - telegraf
     - packages
@@ -21,6 +22,7 @@
   apt_key:
     url: "https://repos.influxdata.com/influxdb.key"
     state: present
+  become: yes
   tags:
     - telegraf
     - packages
@@ -30,6 +32,7 @@
     repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
     filename: "influxdb"
     state: present
+  become: yes
   tags:
     - telegraf
     - packages
@@ -39,7 +42,7 @@
           name=telegraf
           state=installed
   notify: "Restart Telegraf"
-  sudo: yes
+  become: yes
   tags:
   - telegraf
   - packages

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -27,7 +27,7 @@
     - telegraf
     - packages
 
-- name: Add Influxdb repository.
+- name: Add Influxdb repository (using LSB).
   apt_repository:
     repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
     filename: "influxdb"
@@ -36,6 +36,18 @@
   tags:
     - telegraf
     - packages
+  when: ansible_lsb is defined
+
+- name: Add Influxdb repository.
+  apt_repository:
+    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
+    filename: "influxdb"
+    state: present
+  become: yes
+  tags:
+    - telegraf
+    - packages
+  when: ansible_lsb is not defined
 
 - name: "Install telegraf package | Debian"
   action: apt

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -27,7 +27,7 @@
 
 - name: Add Influxdb repository.
   apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
+    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
     filename: "influxdb"
     state: present
   tags:


### PR DESCRIPTION
Use ansible_lsb.codename to set the path to the influxdb repo because "hybrid" distros (when you have testing+unstable, for example) don't work otherwise