### PR TITLE
Do "become" for the steps that require root access on Debian

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -13,6 +13,7 @@
     name: "apt-transport-https"
     state: present
   when: not apt_https_transport.stat.exists
+  become: yes
   tags:
     - telegraf
     - packages
@@ -21,6 +22,7 @@
   apt_key:
     url: "https://repos.influxdata.com/influxdb.key"
     state: present
+  become: yes
   tags:
     - telegraf
     - packages
@@ -30,6 +32,7 @@
     repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
     filename: "influxdb"
     state: present
+  become: yes
   tags:
     - telegraf
     - packages
@@ -39,7 +42,7 @@
           name=telegraf
           state=installed
   notify: "Restart Telegraf"
-  sudo: yes
+  become: yes
   tags:
   - telegraf
   - packages


### PR DESCRIPTION
Actions with apt require being root. Add "become" to those.
"sudo" is deprecated, changed it to "become"