### PR TITLE
Fix the Influxdb repo for "hybrid" debian distros (like "jessie/sid")

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -25,7 +25,7 @@
     - telegraf
     - packages
 
-- name: Add Influxdb repository.
+- name: Add Influxdb repository (using LSB).
   apt_repository:
     repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
     filename: "influxdb"
@@ -33,6 +33,18 @@
   tags:
     - telegraf
     - packages
+  when: ansible_lsb is defined
+
+- name: Add Influxdb repository.
+  apt_repository:
+    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
+    filename: "influxdb"
+    state: present
+  become: yes
+  tags:
+    - telegraf
+    - packages
+  when: ansible_lsb is not defined
 
 - name: "Install telegraf package | Debian"
   action: apt

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -27,7 +27,7 @@
 
 - name: Add Influxdb repository.
   apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
+    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
     filename: "influxdb"
     state: present
   tags:


### PR DESCRIPTION
Use ansible_lsb.codename to set the path to the influxdb repo because "hybrid" distros (when you have testing+unstable, for example) don't work otherwise. This requires LSB, which isn't always installed. If it isn't, it won't work on hybrid distros.