### PR TITLE
support missing agent settings upto telegraf v1.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,16 @@ telegraf_agent_round_interval: True
 telegraf_agent_flush_interval: 10
 telegraf_agent_flush_jitter: 0
 
+#v0.13 settings (not sure if supported in older version):
+telegraf_agent_collection_jitter: 0
+telegraf_agent_metric_batch_size: 1000
+telegraf_agent_metric_buffer_limit: 10000
+telegraf_agent_quiet: False
+
+#v1.1 settings:
+telegraf_agent_logfile: ""
+telegraf_agent_omit_hostname: False
+
 telegraf_agent_rpm_url: https://dl.influxdata.com/telegraf/releases/telegraf-{{ telegraf_agent_version }}{{ telegraf_agent_version_sub_l }}.x86_64.rpm
 telegraf_agent_deb_url: https://dl.influxdata.com/telegraf/releases/telegraf_{{ telegraf_agent_version }}{{ telegraf_agent_version_sub_u }}_amd64.deb
 

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -15,6 +15,16 @@
     round_interval = {{ telegraf_agent_round_interval | lower }}
     flush_interval = "{{ telegraf_agent_flush_interval }}s"
     flush_jitter = "{{ telegraf_agent_flush_jitter }}s"
+{% if telegraf_agent_version|version_compare('0.13', '>=') %}
+    collection_jitter = "{{ telegraf_agent_collection_jitter }}s"
+    metric_batch_size = {{ telegraf_agent_metric_batch_size }}
+    metric_buffer_limit = {{ telegraf_agent_metric_buffer_limit }}
+    quiet = {{ telegraf_agent_quiet | lower }}
+{% endif %}
+{% if telegraf_agent_version|version_compare('1.1', '>=') %}
+    logfile = "{{ telegraf_agent_logfile }}"
+    omit_hostname = {{ telegraf_agent_omit_hostname | lower }}
+{% endif %}
 
 ###############################################################################
 #                                  OUTPUTS                                    #


### PR DESCRIPTION
new feature/settings added in a downward compatible way, so that settings are only added to the config if the telegraf version supports the settings  (and using of course the defaults, if the new role vars were not overridden by the ansible user)
