### PR TITLE
Fix telegraf confguration permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,9 +13,9 @@
   template:
     src: etc-opt-telegraf-telegraf.conf.j2
     dest: /etc/opt/telegraf/telegraf.conf
-    owner: root
-    group: root
-    mode: 0644
+    owner: telegraf
+    group: telegraf
+    mode: 0640
   become: yes
   when: telegraf_agent_version|version_compare('0.10.0', '<')
   notify: "Restart Telegraf"
@@ -24,9 +24,9 @@
   template:
     src: telegraf.conf.j2
     dest: /etc/telegraf/telegraf.conf
-    owner: root
-    group: root
-    mode: 0644
+    owner: telegraf
+    group: telegraf
+    mode: 0640
   become: yes
   when: telegraf_agent_version|version_compare('0.10.0', '>=')
   notify: "Restart Telegraf"
@@ -35,9 +35,9 @@
   template:
     src: "telegraf-extra-plugin.conf.j2"
     dest: "/etc/telegraf/telegraf.d/{{ item.plugin }}.conf"
-    owner: root
-    group: root
-    mode: 0644
+    owner: telegraf
+    group: telegraf
+    mode: 0640
   with_items: "{{ telegraf_plugins_extra }}"
   when: "telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable"
   become: yes

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -12,7 +12,7 @@ def test_telegraf_running_and_enabled(Service, SystemInfo):
 
 def test_telegraf_dot_conf(File):
     telegraf = File("/etc/telegraf/telegraf.conf")
-    assert telegraf.user == "telegrf"
+    assert telegraf.user == "telegraf"
     assert telegraf.group == "telegraf"
     assert telegraf.mode == 0o640
     assert telegraf.contains('[[inputs.cpu]]')

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -12,9 +12,9 @@ def test_telegraf_running_and_enabled(Service, SystemInfo):
 
 def test_telegraf_dot_conf(File):
     telegraf = File("/etc/telegraf/telegraf.conf")
-    assert telegraf.user == "root"
-    assert telegraf.group == "root"
-    assert telegraf.mode == 0o644
+    assert telegraf.user == "telegrf"
+    assert telegraf.group == "telegraf"
+    assert telegraf.mode == 0o640
     assert telegraf.contains('[[inputs.cpu]]')
 
 


### PR DESCRIPTION
With official Telegraf package user and group telegraf is created on install. We should use this permissions on Telegraf configuration files.
For more security file mode should be 0640 not 0644.