### PR TITLE
Remove for-loop in extra-plugin template

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,11 +34,10 @@
 - name: "Copy telegraf extra plugins"
   template:
     src: "telegraf-extra-plugin.conf.j2"
-    dest: "/etc/telegraf/telegraf.d/{{ item.plugin }}.conf"
+    dest: "/etc/telegraf/telegraf.d/extra-plugins.conf"
     owner: telegraf
     group: telegraf
     mode: 0640
-  with_items: "{{ telegraf_plugins_extra }}"
   when: "telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable"
   become: yes
   notify: "Restart Telegraf"

--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -1,6 +1,3 @@
-
-{% if telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable %}
-{% for item in telegraf_plugins_extra %}
 [[inputs.{{ item.plugin }}]]
 {% if item.interval is defined %}
     interval = "{{ item.interval }}s"
@@ -44,7 +41,5 @@
 [[{{item.plugin}}.specifications]]
 {% for items in item.specifications %}
     {{ items }}
-{% endfor %}
-{% endif %}
 {% endfor %}
 {% endif %}

--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -1,3 +1,5 @@
+{% if telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable %}
+{% for item in telegraf_plugins_extra %}
 [[inputs.{{ item.plugin }}]]
 {% if item.interval is defined %}
     interval = "{{ item.interval }}s"
@@ -41,5 +43,7 @@
 [[{{item.plugin}}.specifications]]
 {% for items in item.specifications %}
     {{ items }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Because this is performed by the task itself. Was causing all extra plugin configurations to be written in each sub-configuration file in telegraf.d