### PR TITLE
Use yum repository to install telegraf on RedHat

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Role Variables
 The following parameters can be set for the Telegraf agent:
 
 * `telegraf_agent_version`: The version of Telegraf to install. Default: `1.0.0`
-* `telegraf_agent_rpm_url`: The full path to the RPM file located on a webserver.
 * `telegraf_agent_interval`: The interval configured for sending data to the server. Default: `10`
 * `telegraf_agent_debug`: Run Telegraf in debug mode. Default: `False`
 * `telegraf_agent_round_interval`: Rounds collection interval to 'interval' Default: True

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ With the property `telegraf_plugins_default` it is set to use the default set of
 	  - plugin: swap
 	  - plugin: netstat
 
-Every telegraf agent has these as an default configuration.
+Every telegraf agent has these as a default configuration.
 
 The 2nd parameter `telegraf_plugins_extra` can be used to add plugins specific to the servers goal. Following is an example for using this parameter for MySQL database servers:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The following parameters can be set for the Telegraf agent:
 
 * `telegraf_agent_version`: The version of Telegraf to install. Default: `1.0.0`
 * `telegraf_agent_rpm_url`: The full path to the RPM file located on a webserver.
-* `telegraf_agent_deb_url`:  The full path to the DEB file located on a webserver.
 * `telegraf_agent_interval`: The interval configured for sending data to the server. Default: `10`
 * `telegraf_agent_debug`: Run Telegraf in debug mode. Default: `False`
 * `telegraf_agent_round_interval`: Rounds collection interval to 'interval' Default: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,6 @@
 #telegraf_agent_version: 0.10.1
 telegraf_agent_version: 1.0.0
 telegraf_agent_hostname: "{{ ansible_fqdn }}"
-telegraf_agent_version_sub_l: _beta2
 telegraf_agent_interval: 10
 telegraf_agent_debug: False
 telegraf_agent_round_interval: True
@@ -21,7 +20,6 @@ telegraf_agent_quiet: False
 telegraf_agent_logfile: ""
 telegraf_agent_omit_hostname: False
 
-telegraf_agent_rpm_url: https://dl.influxdata.com/telegraf/releases/telegraf-{{ telegraf_agent_version }}{{ telegraf_agent_version_sub_l }}.x86_64.rpm
 telegraf_agent_tags:
 
 telegraf_agent_output:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@
 telegraf_agent_version: 1.0.0
 telegraf_agent_hostname: "{{ ansible_fqdn }}"
 telegraf_agent_version_sub_l: _beta2
-telegraf_agent_version_sub_u: -beta2
 telegraf_agent_interval: 10
 telegraf_agent_debug: False
 telegraf_agent_round_interval: True
@@ -23,8 +22,6 @@ telegraf_agent_logfile: ""
 telegraf_agent_omit_hostname: False
 
 telegraf_agent_rpm_url: https://dl.influxdata.com/telegraf/releases/telegraf-{{ telegraf_agent_version }}{{ telegraf_agent_version_sub_l }}.x86_64.rpm
-telegraf_agent_deb_url: https://dl.influxdata.com/telegraf/releases/telegraf_{{ telegraf_agent_version }}{{ telegraf_agent_version_sub_u }}_amd64.deb
-
 telegraf_agent_tags:
 
 telegraf_agent_output:

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -25,14 +25,16 @@
     - pyopenssl
     - ndg-httpsclient
 
-- name: "Fetch telegraf installation package | RedHat"
-  action: get_url
-          url="{{ telegraf_agent_rpm_url }}"
-          dest=/tmp/telegraf_{{ telegraf_agent_version }}.x86_64.rpm
-          mode=0440
+- name: "Add yum repository | RedHat"
+  yum_repository:
+    name: influxdb
+    description: InfluxDB Repository - RHEL $releasever
+    baseurl: https://repos.influxdata.com/rhel/$releasever/$basearch/stable
+    gpgcheck: yes
+    gpgkey: https://repos.influxdata.com/influxdb.key
 
 - name: "Install telegraf package | RedHat"
   action: yum
-          name=/tmp/telegraf_{{ telegraf_agent_version }}.x86_64.rpm
+          name="telegraf-{{ telegraf_agent_version }}"
           state=installed
   notify: "Restart Telegraf"


### PR DESCRIPTION
The role does not use a direct download of the rpm package anymore but use the yum repository for InfluxData products as it is advised in the current documentation for installation.
https://docs.influxdata.com/telegraf/v1.2/introduction/installation/

Unused vars are removed.