### PR TITLE
tags: give an option to use AWS tags as telegraf tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The following parameters can be set for the Telegraf agent:
 * `telegraf_agent_round_interval`: Rounds collection interval to 'interval' Default: True
 * `telegraf_agent_flush_interval`: Default data flushing interval for all outputs. Default: 10
 * `telegraf_agent_flush_jitter`: Jitter the flush interval by a random amount. Default: 0
+* `telegraf_agent_aws_tags`: Configure AWS ec2 tags into Telegraf tags section Default: `False`
+* `telegraf_agent_aws_tags_prefix`: Define a prefix for AWS ec2 tags. Default: `""`
 * `telegraf_agent_collection_jitter`: Jitter the collection by a random amount. Default: 0 (since v0.13)
 * `telegraf_agent_metric_batch_size`: The agent metric batch size. Default: 1000  (since v0.13)
 * `telegraf_agent_metric_buffer_limit`: The agent metric buffer limit. Default: 10000  (since v0.13)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ telegraf_agent_debug: False
 telegraf_agent_round_interval: True
 telegraf_agent_flush_interval: 10
 telegraf_agent_flush_jitter: 0
+telegraf_agent_aws_tags: False
+telegraf_agent_aws_tags_prefix: ""
 
 # v0.13 settings (not sure if supported in older version):
 telegraf_agent_collection_jitter: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,18 @@
   include: "Debian.yml"
   when: ansible_os_family == "Debian"
 
+- name: Retrieve ec2 facts
+  ec2_facts:
+  when: telegraf_agent_aws_tags
+
+- name: Retrieve all ec2 tags on the instance
+  ec2_tag:
+    region: '{{ ansible_ec2_placement_region }}'
+    resource: '{{ ansible_ec2_instance_id }}'
+    state: list
+  when: telegraf_agent_aws_tags
+  register: ec2_tags
+
 - name: "Copy the template for versions < 0.10.0"
   template:
     src: etc-opt-telegraf-telegraf.conf.j2

--- a/templates/etc-opt-telegraf-telegraf.conf.j2
+++ b/templates/etc-opt-telegraf-telegraf.conf.j2
@@ -7,6 +7,12 @@
 {% endfor %}
 {% endif %}
 
+{% if telegraf_agent_aws_tags == true and ec2_tags is defined and ec2_tags != None %}
+{% for key, value in ec2_tags.tags.iteritems()%}
+   {{telegraf_agent_aws_tags_prefix}}{{ key }} = "{{ value }}"
+{% endfor %}
+{% endif %}
+
 # Configuration for telegraf itself
 [agent]
     interval = "{{ telegraf_agent_interval }}s"

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -7,6 +7,12 @@
 {% endfor %}
 {% endif %}
 
+{% if telegraf_agent_aws_tags == true and ec2_tags is defined and ec2_tags != None %}
+{% for key, value in ec2_tags.tags.iteritems()%}
+   {{telegraf_agent_aws_tags_prefix}}{{ key }} = "{{ value }}"
+{% endfor %}
+{% endif %}
+
 # Configuration for telegraf agent
 [agent]
     interval = "{{ telegraf_agent_interval }}s"


### PR DESCRIPTION
From : https://github.com/rossmcdonald/telegraf

Add `telegraf_agent_aws_tags` boolean to enable AWS tag in telegraf agent
tags section.

Also add `telegraf_agent_aws_tags_prefix` to allow usage of a prefix on AWS tags name.
