### PR TITLE
Use telegra_global_tags for oldest telegraf versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Full agent settings reference: https://github.com/influxdata/telegraf/blob/maste
 
 You can set tags for the host running telegraf:
 
-	telegraf_agent_tags:
+	telegraf_global_tags:
 	  - tag_name: some_name
 	    tag_value: some_value
 

--- a/templates/etc-opt-telegraf-telegraf.conf.j2
+++ b/templates/etc-opt-telegraf-telegraf.conf.j2
@@ -1,8 +1,8 @@
 # Telegraf configuration
 
 [tags]
-{% if telegraf_agent_tags is defined and telegraf_agent_tags is iterable %}
-{% for item in telegraf_agent_tags %}
+{% if telegraf_global_tags is defined and telegraf_global_tags is iterable %}
+{% for item in telegraf_global_tags %}
     {{ item.tag_name }} = "{{ item.tag_value }}"
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Users will use the same config key for global tags regardless of the
telegraf version.
Also fix the documentation about this parameter to be consistent with
changes from #37