### PR TITLE
plugins: be able to specify the filename of extra plugings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 - name: "Copy telegraf extra plugins"
   template:
     src: "telegraf-extra-plugin.conf.j2"
-    dest: "/etc/telegraf/telegraf.d/{{ item.plugin }}.conf"
+    dest: "/etc/telegraf/telegraf.d/{{ item.filename | default(item.plugin) }}.conf"
     owner: telegraf
     group: telegraf
     mode: 0640


### PR DESCRIPTION
This commit allow you to override the filename used to create the extra
config file for a plugin.

You might need it If you want to call several time the
same input plugin : for example https://github.com/influxdata/telegraf/issues/2294

Explain here : https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md#multiple-inputs-of-the-same-type

An input plugin can be called several time. Allowing to override the filename seems to be the best solution
to not break ansible-telegraf configuration and offer a way to call several time an input.