### PR TITLE
Allow to override RedHat release version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,3 +43,6 @@ telegraf_plugins_default:
   - plugin: netstat
 
 telegraf_plugins_extra:
+
+# RedHat specific settings for convenience
+telegraf_redhat_releasever: "$releasever"

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,7 +4,7 @@
   yum_repository:
     name: influxdb
     description: InfluxDB Repository - RHEL $releasever
-    baseurl: https://repos.influxdata.com/rhel/$releasever/$basearch/stable
+    baseurl: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
     gpgcheck: yes
     gpgkey: https://repos.influxdata.com/influxdb.key
 


### PR DESCRIPTION
Systems like Amazon Linux are from the RedHat OS family but have a
specific release versions notation. Influxdata does not always provide a
yum repository with these versions, so it should be something to override
in order to install telegraf from a different release version path.

For instance, Influxdata currently provides telegraf for both RHEL
versions 6 and 2016.09 with packages being the same (same checksums).
This is because of Amazon Linux 2016.09 being a RHEL version 6.
However, now Amazon Linux 2017.09 is out, still being a RHEL 6 but
Influxdata does not provide a 2017.09 release version path so we cannon
install telegraf on it. Overriding the release version to 6 or 2016.09
will allow to install.