### PR TITLE
Let telegraf find the hostname if not provided

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for ansible-telegraf
 
 telegraf_agent_version: 1.4.0
-telegraf_agent_hostname: "{{ ansible_fqdn }}"
+#telegraf_agent_hostname: "{{ ansible_fqdn }}"
 telegraf_agent_interval: 10
 telegraf_agent_debug: False
 telegraf_agent_round_interval: True

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -17,7 +17,9 @@
 [agent]
     interval = "{{ telegraf_agent_interval }}s"
     debug = {{ telegraf_agent_debug | lower }}
+{% if telegraf_agent_hostname is defined %}
     hostname = "{{ telegraf_agent_hostname }}"
+{% endif %}
     round_interval = {{ telegraf_agent_round_interval | lower }}
     flush_interval = "{{ telegraf_agent_flush_interval }}s"
     flush_jitter = "{{ telegraf_agent_flush_jitter }}s"


### PR DESCRIPTION
In some architectures, the hostname will be unknown when using the role.
Telegraf is able to detect the OS hostname and this should be used in
these cases.

Using services like Amazon Web Services Auto Scaling Group, users cannot
run the role on running instances. It will be better to configure
telegraf in an image (AMI in AWS context) and instances will be started
based on this image.
It means actual instances hostnames will be unknown at configuration
time. The current state of the role will write in the config file the
hostname of the instance used to generate the image, so all future
machines will send points with the same hostname.

This patch still allows to specify an hostname to write in the telegraf
configuration but allso let telegraf find the hostname itself on service
start time.