### PR TITLE
Improved comments, split up role, moved tags and added defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,6 @@ telegraf_plugins_default:
   - plugin: swap
   - plugin: netstat
   - plugin: processes
-  - plugin: diskio
   - plugin: kernel
 
 # extra configuration - /etc/telegraf/telegraf.d/*

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ telegraf_agent_output:
       - database = "telegraf"
       - precision = "s"
 
+# defaults - /etc/telegraf/telegraf.conf
 telegraf_plugins_default:
   - plugin: cpu
     config:
@@ -41,8 +42,12 @@ telegraf_plugins_default:
   - plugin: system
   - plugin: swap
   - plugin: netstat
+  - plugin: processes
+  - plugin: diskio
+  - plugin: kernel
 
-telegraf_plugins_extra:
+# extra configuration - /etc/telegraf/telegraf.d/*
+telegraf_plugins_extra: []
 
 # RedHat specific settings for convenience
 telegraf_redhat_releasever: "$releasever"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -4,9 +4,6 @@
   stat:
     path: /usr/lib/apt/methods/https
   register: apt_https_transport
-  tags:
-    - telegraf
-    - packages
 
 - name: Install APT HTTPS transport.
   apt:
@@ -14,18 +11,12 @@
     state: present
   when: not apt_https_transport.stat.exists
   become: yes
-  tags:
-    - telegraf
-    - packages
 
 - name: Download Telegraf apt key.
   apt_key:
     url: "https://repos.influxdata.com/influxdb.key"
     state: present
   become: yes
-  tags:
-    - telegraf
-    - packages
 
 - name: Add Telegraf repository (using LSB).
   apt_repository:
@@ -33,9 +24,6 @@
     filename: "telegraf"
     state: present
   become: yes
-  tags:
-    - telegraf
-    - packages
   when: ansible_lsb is defined and ansible_lsb.codename is defined
 
 - name: Add Telegraf repository.
@@ -44,17 +32,11 @@
     filename: "telegraf"
     state: present
   become: yes
-  tags:
-    - telegraf
-    - packages
   when: ansible_lsb is not defined or ansible_lsb.codename is not defined
 
 - name: "Install telegraf package | Debian"
   apt:
-    name: telegraf
+    name: "telegraf"
     state: installed
   notify: "Restart Telegraf"
   become: yes
-  tags:
-    - telegraf
-    - packages

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,4 +1,5 @@
 ---
+# description: RedHat specific installation
 
 - name: "Add yum repository | RedHat"
   yum_repository:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,51 @@
+---
+# description: Configure telegraf and get all relevent ec2 information
+
+- name: Retrieve ec2 facts
+  ec2_facts:
+  when: telegraf_agent_aws_tags
+
+- name: Retrieve all ec2 tags on the instance
+  ec2_tag:
+    region: '{{ ansible_ec2_placement_region }}'
+    resource: '{{ ansible_ec2_instance_id }}'
+    state: list
+  when: telegraf_agent_aws_tags
+  register: ec2_tags
+
+- name: "Copy the template for versions < 0.10.0"
+  template:
+    src: etc-opt-telegraf-telegraf.conf.j2
+    dest: /etc/opt/telegraf/telegraf.conf
+    owner: telegraf
+    group: telegraf
+    mode: 0640
+  become: yes
+  when: telegraf_agent_version|version_compare('0.10.0', '<')
+  notify: "Restart Telegraf"
+
+- name: "Copy the template for versions >= 0.10.0"
+  template:
+    src: telegraf.conf.j2
+    dest: /etc/telegraf/telegraf.conf
+    owner: telegraf
+    group: telegraf
+    mode: 0640
+  become: yes
+  when: telegraf_agent_version|version_compare('0.10.0', '>=')
+  notify: "Restart Telegraf"
+
+- name: "Copy telegraf extra plugins"
+  template:
+    src: "telegraf-extra-plugin.conf.j2"
+    dest: "/etc/telegraf/telegraf.d/{{ item.filename | default(item.plugin) }}.conf"
+    owner: telegraf
+    group: telegraf
+    mode: 0640
+  with_items: "{{ telegraf_plugins_extra }}"
+  when: "telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable"
+  become: yes
+  notify: "Restart Telegraf"
+
+- name: "Force restart service after reread config"
+  meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,49 +8,9 @@
 - name: "Install the correct repository"
   include: "Debian.yml"
   when: ansible_os_family == "Debian"
+  tags:
+    - telegraf
+    - packages
 
-- name: Retrieve ec2 facts
-  ec2_facts:
-  when: telegraf_agent_aws_tags
-
-- name: Retrieve all ec2 tags on the instance
-  ec2_tag:
-    region: '{{ ansible_ec2_placement_region }}'
-    resource: '{{ ansible_ec2_instance_id }}'
-    state: list
-  when: telegraf_agent_aws_tags
-  register: ec2_tags
-
-- name: "Copy the template for versions < 0.10.0"
-  template:
-    src: etc-opt-telegraf-telegraf.conf.j2
-    dest: /etc/opt/telegraf/telegraf.conf
-    owner: telegraf
-    group: telegraf
-    mode: 0640
-  become: yes
-  when: telegraf_agent_version|version_compare('0.10.0', '<')
-  notify: "Restart Telegraf"
-
-- name: "Copy the template for versions >= 0.10.0"
-  template:
-    src: telegraf.conf.j2
-    dest: /etc/telegraf/telegraf.conf
-    owner: telegraf
-    group: telegraf
-    mode: 0640
-  become: yes
-  when: telegraf_agent_version|version_compare('0.10.0', '>=')
-  notify: "Restart Telegraf"
-
-- name: "Copy telegraf extra plugins"
-  template:
-    src: "telegraf-extra-plugin.conf.j2"
-    dest: "/etc/telegraf/telegraf.d/{{ item.filename | default(item.plugin) }}.conf"
-    owner: telegraf
-    group: telegraf
-    mode: 0640
-  with_items: "{{ telegraf_plugins_extra }}"
-  when: "telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable"
-  become: yes
-  notify: "Restart Telegraf"
+- name: "Configure telegraf"
+  include: "configure.yml"

--- a/templates/etc-opt-telegraf-telegraf.conf.j2
+++ b/templates/etc-opt-telegraf-telegraf.conf.j2
@@ -1,4 +1,4 @@
-# Telegraf configuration
+### MANAGED BY {{ role_path|basename }} ANSIBLE ROLE ###
 
 [tags]
 {% if telegraf_global_tags is defined and telegraf_global_tags is iterable %}

--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -1,3 +1,5 @@
+### MANAGED BY {{ role_path|basename }} ANSIBLE ROLE ###
+
 [[inputs.{{ item.plugin }}]]
 {% if item.interval is defined %}
     interval = "{{ item.interval }}s"

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -1,4 +1,4 @@
-# Telegraf configuration
+### MANAGED BY {{ role_path|basename }} ANSIBLE ROLE ###
 
 [global_tags]
 {% if telegraf_global_tags is defined and telegraf_global_tags is iterable %}


### PR DESCRIPTION
- Added some commenting inside of defaults to clarify which variables
  adjust which files

- Split up the role taking items out of main.yml in tasks. This is to
  improve clarity of what each bit of Ansible code is doing.

- Tags were defined for each and every task within the Debian.yml moved
  ths up to main.yml so they don't need repeating every task adding
  clutter.

- Added some extra default plugins, as of current release version these
  are now within the default configuration but were missing from this
  role.

- Added some commenting inside the templates and the top of some tasks
  to clarify where the templated file was coming from.