### PR TITLE
Pin apt key ID

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -15,6 +15,7 @@
 - name: Download Telegraf apt key.
   apt_key:
     url: "https://repos.influxdata.com/influxdb.key"
+    id: 2582E0C5
     state: present
   become: yes
 


### PR DESCRIPTION
**Description of PR**
ID is specified so ansible can check if the key is already there without
downloading the file.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
 Useful to keep the role woring when the key has
already been added on systems where DL won't work with the module
because of certificate validation (Ubuntu 14.04).
