### PR TITLE
Wen copying/removing plugins show only plugin name

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -67,6 +67,8 @@
     group: telegraf
     mode: 0640
   with_dict: "{{ telegraf_plugins_extra }}"
+  loop_control:
+    label: "{{ item.key }}"
   when: "telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable and item.value.state|default('present') != 'absent'"
   become: yes
   notify: "Restart Telegraf"
@@ -76,6 +78,8 @@
     path: "/etc/telegraf/telegraf.d/{{ item.key }}.conf"
     state: absent
   with_dict: "{{ telegraf_plugins_extra }}"
+  loop_control:
+    label: "{{ item.key }}"
   when: "telegraf_plugins_extra is defined and telegraf_plugins_extra is iterable and item.value.state|default('present') == 'absent'"
   become: yes
   notify: "Restart Telegraf"


### PR DESCRIPTION
**Description of PR**

This hides the plugin configuration from Ansible logs from copying/removing plugin tasks. Configuration can contain somewhat sensitive data sometimes and the output can be very verbose in some cases.

**Type of change**

Bugfix Pull Request