### PR TITLE
telegraf-extra-plugin.conf.j2: fix template typo

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -28,6 +28,15 @@ provisioner:
   inventory:
     group_vars:
       all:
+        telegraf_plugins_extra:
+          percpu-usage:
+            plugin: cpu
+            config:
+              - percpu = true
+              - totalcpu = false
+              - name_override = "percpu_usage"
+              - fielddrop = ["cpu_time*"]
+
         telegraf_plugins_default:
           - plugin: cpu
             config:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,6 +21,15 @@ def test_telegraf_dot_conf(File):
     assert telegraf.contains('[[inputs.cpu]]')
 
 
+def test_telegraf_dot_d(File):
+    telegraf = File("/etc/telegraf/telegraf.d/percpu-usage.conf")
+    assert telegraf.user == "telegraf"
+    assert telegraf.group == "telegraf"
+    assert telegraf.mode == 0o640
+    assert telegraf.contains('[[inputs.cpu]]')
+    assert telegraf.contains('totalcpu = false')
+
+
 def test_telegraf_package(Package, SystemInfo):
     telegraf = Package('telegraf')
     assert telegraf.is_installed

--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -6,7 +6,7 @@
 {% endif %}
 {% if item.value.config is defined and item.value.config is iterable %}
 {% for items in item.value.config %}
-    {% raw %}{{ items }}{%  endraw %}}
+    {{ items }}
 {% endfor %}
 {% endif %}
 {% if item.value.tags is defined and item.value.tags is iterable %}


### PR DESCRIPTION
**Description of PR**

Related to commend : https://github.com/dj-wasabi/ansible-telegraf/commit/3cccb6ba50f0feb6a972dfd4498e146f9c84a35c#r31366694

Fix typo added in template `telegraf-extra-plugin.conf.j2`

Also add molecule tests to validate file generated with `telegraf_plugins_extra` option.

The added test template come from `Multiple inputs of the same type` (https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md#multiple-inputs-of-the-same-type)

**Type of change**

Bugfix Pull Request


**Fixes an issue**

No issues, just comment https://github.com/dj-wasabi/ansible-telegraf/commit/3cccb6ba50f0feb6a972dfd4498e146f9c84a35c#r31366694