### PR TITLE
Added default pluging if nothing is configured

### DIFF
--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -98,3 +98,10 @@
 {% endif %}
 {% endfor %}
 {% endif %}
+
+{% if telegraf_plugins_default is defined and telegraf_plugins_default|length == 0 %}
+{% if telegraf_plugins_extra is defined and telegraf_plugins_extra.keys() | length == 0 %}
+# No plugins configured, added a mem plugin so telegraf doesn't stop working.
+[[inputs.mem]]
+{% endif %}
+{% endif %}


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->

Added a default `mem` plugin when no other plugin is configured to prevent stopping/crashing Telegraf instance.

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fixes #63