### PR TITLE
Replace 'ec2_facts' with 'ec2_metadata_facts' to fix a deprecation warning

### DIFF
--- a/tasks/configure_linux.yml
+++ b/tasks/configure_linux.yml
@@ -2,7 +2,7 @@
 # description: Configure telegraf and get all relevent ec2 information
 
 - name: Retrieve ec2 facts
-  ec2_facts:
+  ec2_metadata_facts:
   when:
     - telegraf_agent_aws_tags
 


### PR DESCRIPTION
**Description of PR**
Just a one-line change to fix the following deprecation warning:

```ansible
[DEPRECATION WARNING]: ec2_facts is kept for backwards compatibility but usage is discouraged. The module
 documentation details page may explain more about this rationale.. This feature will be removed in a
future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

It seems like `ec2_metadata_facts` is a drop-in replacement for `ec2_facts`. It was added in Ansible 2.4, which is the minimum version you support with this role, so I think it should be ok?

Thanks!

**Type of change**
Bugfix Pull Request
