### PR TITLE
A few enhancements and fixes to windows support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,7 +57,7 @@ telegraf_redhat_releasever: "$releasever"
 
 telegraf_win_install_dir: 'C:\Telegraf'
 telegraf_win_logfile: 'C:\\Telegraf\\telegraf.log'
-telegraf_win_include: 'C:\Telegraf\telegraf_agent.d\'
+telegraf_win_include: 'C:\Telegraf\telegraf_agent.d'
 telegraf_win_service_args:
   - -service install
   - -config {{ telegraf_win_install_dir }}\telegraf\telegraf.conf

--- a/tasks/configure_windows.yml
+++ b/tasks/configure_windows.yml
@@ -35,7 +35,7 @@
 - name: "Windows | Copy telegraf extra plugins"
   win_template:
     src: "telegraf-extra-plugin.conf.j2"
-    dest: "/etc/telegraf/telegraf.d/{{ item.key }}.conf"
+    dest: '{{ telegraf_win_include }}\{{ item.key }}.conf'
   with_dict: "{{ telegraf_plugins_extra }}"
   loop_control:
     label: "{{ item.key }}"
@@ -47,7 +47,7 @@
 
 - name: "Windows | Remove telegraf extra plugins"
   win_file:
-    path: "/etc/telegraf/telegraf.d/{{ item.key }}.conf"
+    path: '{{ telegraf_win_include }}\{{ item.key }}.conf'
     state: absent
   with_dict: "{{ telegraf_plugins_extra }}"
   loop_control:

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -94,6 +94,16 @@
     {{ items }}
 {% endfor %}
 {% endif %}
+{% if item.objects is defined and item.objects is iterable %}
+{% for object in item.objects %}
+[[inputs.{{ item.plugin }}.object]]
+  ObjectName = {{ object.name | tojson }}
+  Instances = {{ object.instances | default(["*"]) }}
+  Counters = {{ object.counters | default(["*"]) }}
+  Measurement = {{ object.measurement | default("win_perf_counters") | tojson }}
+  IncludeTotal = {{ object.total | default(false) | string | lower }}
+{% endfor %}
+{% endif %}
 {% if item.specifications is defined and item.specifications is iterable %}
 [[{{item.plugin}}.specifications]]
 {% for items in item.specifications %}


### PR DESCRIPTION
- Add object to template for windows perf counters with defaults
- Fix reference to include directory

**Description of PR**
I found it helpful to explicitly support what telegraf expects when defining win_perf_counters plugin objects as defined [in their docs](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/win_perf_counters).
I don't particularly like the fact that a new `objects` property is effectively hijacked for use with the win_perf_counters plugin exclusively, but if you have other ideas on how to handle that let me know - don't want to break compatibility with linux config etc.

I also discovered a small bug in the definition of the windows plugin includes directory (just needed to use the variable)

My definition for a win_perf_counter plugin now looks like this instead of having to define line items in a list of configs to get multiple objects in the template:

```yml
telegraf_plugins_default:
  - plugin: win_perf_counters
    config:
      - UsePerfCounterTime = true
    objects:
      - name: Processor
        measurement: win_cpu
        counters:
          - "% User Time"
          - "% Processor Time"
        total: true

      - name: System
        measurement: win_system
        instances: ["------"]
        counters:
          - "Processes"
          - "Threads"
```


**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request
Bugfix Pull Request

