### PR TITLE
Add support for extra win_perf_counters and prevent python u'' strings

### DIFF
--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -39,6 +39,16 @@
     {{ items }}
 {% endfor %}
 {% endif %}
+{% if item.value.objects is defined and item.value.objects is iterable %}
+{% for object in item.value.objects %}
+[[inputs.{{ item.value.plugin | default(item.key) }}.object]]
+  ObjectName = {{ object.name | to_json }}
+  Instances = {{ object.instances | default(["*"]) | to_json }}
+  Counters = {{ object.counters | default(["*"]) | to_json }}
+  Measurement = {{ object.measurement | default("win_perf_counters") | to_json }}
+  IncludeTotal = {{ object.total | default(false) | string | lower }}
+{% endfor %}
+{% endif %}
 {% if item.value.specifications is defined and item.value.specifications is iterable %}
 [[{{item.value.plugin | default(item.key)}}.specifications]]
 {% for items in item.value.specifications %}

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -98,8 +98,8 @@
 {% for object in item.objects %}
 [[inputs.{{ item.plugin }}.object]]
   ObjectName = {{ object.name | to_json }}
-  Instances = {{ object.instances | default(["*"]) }}
-  Counters = {{ object.counters | default(["*"]) }}
+  Instances = {{ object.instances | default(["*"]) | to_json }}
+  Counters = {{ object.counters | default(["*"]) | to_json }}
   Measurement = {{ object.measurement | default("win_perf_counters") | to_json }}
   IncludeTotal = {{ object.total | default(false) | string | lower }}
 {% endfor %}


### PR DESCRIPTION
**Description of PR**
* Fixes an issue where python renders a list of counters as [u'CounterA', u'CounterB'] in telegraf config
* Adds support for including win_perf_counters as 'extra' plugins 

**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request
Bugfix Pull Request

**Fixes an issue**
* Fixes an issue where python renders a list of counters as [u'CounterA', u'CounterB'] in telegraf config
