### PR TITLE
Add Yum repo support for Amazon Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,6 +55,12 @@ telegraf_plugins_extra_exclusive: False
 # RedHat specific settings for convenience
 telegraf_redhat_releasever: "$releasever"
 
+telegraf_yum_baseurl:
+  amazon: "https://repos.influxdata.com/centos/6/$basearch/stable"
+  centos: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
+  default: "https://repos.influxdata.com/{{ ansible_distribution|lower }}/{{ telegraf_redhat_releasever }}/$basearch/stable"
+  redhat: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
+
 telegraf_win_install_dir: 'C:\Telegraf'
 telegraf_win_logfile: 'C:\\Telegraf\\telegraf.log'
 telegraf_win_include: 'C:\Telegraf\telegraf_agent.d'

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -16,7 +16,7 @@
   yum_repository:
     name: influxdb
     description: InfluxDB Repository - RHEL $releasever
-    baseurl: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
+    baseurl: "{{ telegraf_yum_baseurl[ansible_distribution|lower] | default(telegraf_yum_baseurl['default']) }}"
     gpgcheck: yes
     gpgkey: https://repos.influxdata.com/influxdb.key
 


### PR DESCRIPTION
**Add support for Yum repos on Amazon Linux **
Adds new variable telegraf_yum_baseurl which selects a different baseurl depending on ansible_distribution

**Type of change**
Bugfix Pull Request

**Fixes an issue**
No existing issue tracked, but without this change you would get the following on Amazon Linux:

`fatal: [HOSTNAME]: FAILED! => changed=false
  msg: |-
    Failure talking to yum: failure: repodata/repomd.xml from influxdb: [Errno 256] No more mirrors to try.
    https://repos.influxdata.com/rhel/2018.03/x86_64/stable/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
fatal: [HOSTNAME]: FAILED! => changed=false`
