### PR TITLE
[bug] debian - add cache_valid_time

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -49,6 +49,7 @@
   apt:
     name: "{{ telegraf_agent_package }}"
     state: "{{ telegraf_agent_package_state }}"
+    cache_valid_time: 900
     force: True
   notify: "Restart Telegraf"
   become: yes


### PR DESCRIPTION
**Description of PR**

This change allows to workaround the version change of telegraf. When you dont refresh the cache before installing new versions arent available.

**Type of change**

Bugfix Pull Request