### PR TITLE
Fix tagpass and tagdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Specifying an output. The default is set to localhost, you'll have to specify th
 	    config:
 	      - urls = ["http://localhost:8086"]
 	      - database = "telegraf"
-            tagpass:
-              - diskmetrics = ["true"]
+        tagpass:
+          - diskmetrics = ["true"]
 
 The config will be printed line by line into the configuration, so you could also use:
 

--- a/templates/etc-opt-telegraf-telegraf.conf.j2
+++ b/templates/etc-opt-telegraf-telegraf.conf.j2
@@ -27,6 +27,18 @@
 {% for items in item.config %}
     {{ items }}
 {% endfor %}
+{% if item.tagpass is defined and item.tagpass is iterable %}
+[outputs.{{ item.type }}.tagpass]
+{% for items in item.tagpass %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.tagdrop is defined and item.tagdrop is iterable %}
+[outputs.{{ item.type }}.tagdrop]
+{% for items in item.tagdrop %}
+    {{ items }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/templates/etc-opt-telegraf-telegraf.conf.j2
+++ b/templates/etc-opt-telegraf-telegraf.conf.j2
@@ -55,13 +55,13 @@
 {% endfor %}
 {% endif %}
 {% if item.tagpass is defined and item.tagpass is iterable %}
-[item.{{ item.plugin }}.tagpass]
+[inputs.{{ item.plugin }}.tagpass]
 {% for items in item.tagpass %}
     {{ items }}
 {% endfor %}
 {% endif %}
 {% if item.tagdrop is defined and item.tagdrop is iterable %}
-[item.{{ item.plugin }}.tagdrop]
+[inputs.{{ item.plugin }}.tagdrop]
 {% for items in item.tagdrop %}
     {{ items }}
 {% endfor %}

--- a/templates/etc-opt-telegraf-telegraf.conf.j2
+++ b/templates/etc-opt-telegraf-telegraf.conf.j2
@@ -43,13 +43,13 @@
 {% endfor %}
 {% endif %}
 {% if item.tagpass is defined and item.tagpass is iterable %}
-[{{ item.plugin }}.tagpass]
+[item.{{ item.plugin }}.tagpass]
 {% for items in item.tagpass %}
     {{ items }}
 {% endfor %}
 {% endif %}
 {% if item.tagdrop is defined and item.tagdrop is iterable %}
-[{{ item.plugin }}.tagdrop]
+[item.{{ item.plugin }}.tagdrop]
 {% for items in item.tagdrop %}
     {{ items }}
 {% endfor %}

--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -16,13 +16,13 @@
 {% endfor %}
 {% endif %}
 {% if item.value.tagpass is defined and item.value.tagpass is iterable %}
-[{{ item.value.plugin | default(item.key) }}.tagpass]
+[inputs.{{ item.value.plugin | default(item.key) }}.tagpass]
 {% for items in item.value.tagpass %}
     {{ items }}
 {% endfor %}
 {% endif %}
 {% if item.value.tagdrop is defined and item.value.tagdrop is iterable %}
-[{{ item.value.plugin | default(item.key) }}.tagdrop]
+[inputs.{{ item.value.plugin | default(item.key) }}.tagdrop]
 {% for items in item.value.tagdrop %}
     {{ items }}
 {% endfor %}

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -46,6 +46,18 @@
 {% for items in item.config %}
     {{ items }}
 {% endfor %}
+{% if item.tagpass is defined and item.tagpass is iterable %}
+[outputs.{{ item.type }}.tagpass]
+{% for items in item.tagpass %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.tagdrop is defined and item.tagdrop is iterable %}
+[outputs.{{ item.type }}.tagdrop]
+{% for items in item.tagdrop %}
+    {{ items }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -71,13 +71,13 @@
 {% endfor %}
 {% endif %}
 {% if item.tagpass is defined and item.tagpass is iterable %}
-[{{ item.plugin }}.tagpass]
+[inputs.{{ item.plugin }}.tagpass]
 {% for items in item.tagpass %}
     {{ items }}
 {% endfor %}
 {% endif %}
 {% if item.tagdrop is defined and item.tagdrop is iterable %}
-[{{ item.plugin }}.tagdrop]
+[inputs.{{ item.plugin }}.tagdrop]
 {% for items in item.tagdrop %}
     {{ items }}
 {% endfor %}


### PR DESCRIPTION
**Description of PR**
tagpass and tagdrop are ignored when not prefixed with _inputs_.

**Type of change**
Bugfix Pull Request

Also, out of curiosity, what do the pass, drop and specifications do? I can not find any documentation on this. Seems to me it does nothing and could be removed.