### PR TITLE
Updating Telegraf default to 1.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ More information: [https://github.com/influxdata/telegraf/blob/master/docs/FAQ.m
 	# Force host networking mode, so Docker Engine Host traffic metrics can be gathered.
 	telegraf_agent_docker_network_mode: host
 	# Force a specific image tag.
-	telegraf_agent_version: 1.9.3-alpine
+	telegraf_agent_version: 1.9.4-alpine
 
 	telegraf_plugins_default:
 	  - plugin: cpu

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ansible-telegraf
 
-telegraf_agent_version: 1.9.3
+telegraf_agent_version: 1.9.4
 telegraf_agent_version_patch: 1
 telegraf_agent_package: telegraf
 telegraf_agent_package_state: present


### PR DESCRIPTION
**Description of PR**
Updating Telegraf default to 1.9.4

**Type of change**
Bugfix Pull Request

**Fixes an issue**

This issue is getting pretty redundant, the telegraf apt repository is annoying for not keeping older releases. Switching to telegraf github's releases would be a solution.

Signed-off-by: Steve Durrheimer <s.durrheimer@gmail.com>