### PR TITLE
Added the use_proxy argument to use a proxy (or not)

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -68,6 +68,9 @@
     url: https://dl.influxdata.com/telegraf/releases/{{ telegraf_agent_package_file_deb }}
     dest: "{{ telegraf_agent_package }}"
     use_proxy: "{{ true if http_proxy is defined and http_proxy else false }}"
+  environment:
+    http_proxy: "{{ http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ https_proxy | default(None) | default(omit) }}"
   when:
     - telegraf_agent_package_method == "online"
 

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -67,6 +67,7 @@
   get_url:
     url: https://dl.influxdata.com/telegraf/releases/{{ telegraf_agent_package_file_deb }}
     dest: "{{ telegraf_agent_package }}"
+    use_proxy: "{{ true if http_proxy is defined and http_proxy else false }}"
   when:
     - telegraf_agent_package_method == "online"
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -27,6 +27,7 @@
   get_url:
     url: https://dl.influxdata.com/telegraf/releases/{{ telegraf_agent_package_file_rpm }}
     dest: "{{ telegraf_agent_package }}"
+    use_proxy: "{{ true if http_proxy is defined and http_proxy else false }}"
   when:
     - telegraf_agent_package_method == "online"
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -28,6 +28,9 @@
     url: https://dl.influxdata.com/telegraf/releases/{{ telegraf_agent_package_file_rpm }}
     dest: "{{ telegraf_agent_package }}"
     use_proxy: "{{ true if http_proxy is defined and http_proxy else false }}"
+  environment:
+    http_proxy: "{{ http_proxy | default(None) | omit }}"
+    https_proxy: "{{ https_proxy | default(None) | omit }}"
   when:
     - telegraf_agent_package_method == "online"
 


### PR DESCRIPTION
**Description of PR**
Allow the download of the "online" installation to go via an proxy.

**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fixes #96