### PR TITLE
on FreeBSD the telegeraf.conf is in root of /usr/local/etc.

### DIFF
--- a/tasks/configure_linux.yml
+++ b/tasks/configure_linux.yml
@@ -8,7 +8,7 @@
 
 - name: "Add prefix path"
   set_fact:
-    telegraf_agent_config_path: /usr/local/etc/telegraf
+    telegraf_agent_config_path: /usr/local/etc
   when:
     - ansible_os_family == "FreeBSD"
 


### PR DESCRIPTION
**Description of PR**
so I changed the telegraf_agent_config_path. now the telegraf rc scripts finds the right config and no error about missing directories is thrown.

**Type of change**
Bugfix Pull Request