### PR TITLE
Fix: ensure apt-cache is updated before install

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -74,6 +74,7 @@
   apt:
     name: "{{ telegraf_agent_package }}"
     state: "{{ telegraf_agent_package_state }}"
+    update_cache: yes
   register: is_telegraf_package_installed
   until: is_telegraf_package_installed is succeeded
   notify: "Restart Telegraf"


### PR DESCRIPTION
**Description of PR**
A fix to installing a newer version when using latest `telegraf_agent_package_state: latest` and an older version was already cached in apt.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
Should fix the issue mentioned in [this comment][1], and possibly the original issue as well, if we try tagging a wildcard version.

Dear reviewer, kindly ensure that this behavior does not need a toggle, otherwise we can add one. Also, we should try running with a version tag such as `telegraf_agent_version: 1.10*` to check if we're able to install the latest patch version if another one already exists.

[1]: https://github.com/dj-wasabi/ansible-telegraf/issues/95#issuecomment-496605448
