### PR TITLE
Adding support for arm64 systems

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -16,6 +16,12 @@
   when:
     - ansible_architecture == "x86_64"
 
+- name: "Debian | Set telegraf_agent_package_arch specific for arm64"
+  set_fact:
+    telegraf_agent_package_arch: "armhf"
+  when:
+    - ansible_architecture == "arm64"
+
 - name: "Debian | Ensure the system can use the HTTPS transport for APT"
   stat:
     path: /usr/lib/apt/methods/https


### PR DESCRIPTION
Adds support for `arm64` based systems (AWS `a1.*` instances).

**Description of PR**
Sets the `telegraf_agent_package_arch` to `armhf` when ansible_architecture is `arm64`

**Type of change**
Feature Pull Request