### PR TITLE
Support postgresql_extensible queries

### DIFF
--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -47,3 +47,11 @@
   IncludeTotal = {{ object.total | default(false) | string | lower }}
 {% endfor %}
 {% endif %}
+{% if item.value.queries is defined and item.value.queries is iterable %}
+{% for query in item.value.queries %}
+[[inputs.{{ item.value.plugin | default(item.key) }}.query]]
+{% for item in item.value.queries[query] %}
+    {{ item }}
+{% endfor %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
**Description of PR**
Support postgresql_extensible queries. Split over different files they won't work so we need to write them in same extra plugin file. 
Syntax example:
```yaml
telegraf_plugins_extra:
  postgresql_extensible:
    config:
      - address = "postgres://pgmonitor:pgmon@localhost/postgres"
    queries:
      schemas_size:
        - sqlquery = "SELECT schema_name, pg_size_pretty(sum(table_size)::bigint) as disk_space, ((sum(table_size)::bigint) / 1024) / 1024 as size_MB FROM (SELECT pg_catalog.pg_namespace.nspname as schema_name, pg_relation_size(pg_catalog.pg_class.oid) as table_size FROM pg_catalog.pg_class JOIN pg_catalog.pg_namespace ON relnamespace = pg_catalog.pg_namespace.oid) t WHERE t.schema_name not in ('information_schema','pg_catalog','pg_toast') GROUP BY schema_name ORDER BY schema_name"
        - version = 901
        - withdbname = false
        - tagvalue = "schema_name"
        - measurement = "postgresql_schemas_size"
      connections:
        - sqlquery="select count(1) as amount, state from pg_stat_activity where usename != 'dbmonitor' group by state"
        - version=901
        - withdbname=false
        - tagvalue="state"
        - measurement="postgresql_connections"
      stat_replication:
        - sqlquery="select pg_xlog_location_diff(sent_location, write_location)::integer as write_lag, pg_xlog_location_diff(sent_location, flush_location)::integer as flush_lag, pg_xlog_location_diff(sent_location, replay_location)::integer as replay_lag from pg_stat_replication;"
        - version=901
        - withdbname=false
        - tagvalue=""
        - measurement="postgresql_stat_replication"
```
**Type of change**

Feature Pull Request


