### PR TITLE
gpgkey yum repo fix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,7 @@ telegraf_yum_baseurl:
   centos: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
   default: "https://repos.influxdata.com/{{ ansible_distribution|lower }}/{{ telegraf_redhat_releasever }}/$basearch/stable"
   redhat: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
+telegraf_yum_gpgkey: "https://repos.influxdata.com/influxdb.key"
 
 telegraf_win_install_dir: 'C:\Telegraf'
 telegraf_win_logfile: 'C:\\Telegraf\\telegraf.log'

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -18,8 +18,8 @@
     name: influxdb
     description: InfluxDB Repository - RHEL $releasever
     baseurl: "{{ telegraf_yum_baseurl[ansible_distribution|lower] | default(telegraf_yum_baseurl['default']) }}"
-    gpgcheck: yes
-    gpgkey: https://repos.influxdata.com/influxdb.key
+    gpgcheck: "{{ telegraf_yum_gpgcheck | default('true') }}"
+    gpgkey: "{{ telegraf_yum_gpgkey }}"
   become: yes
   when:
     - telegraf_agent_package_method == "repo"


### PR DESCRIPTION
**Description of PR**
Fix of downloading gpgkey from mirrors.
Helpful when we use local mirrors in the organization and do not have internet access (repos.influxdb).

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
