### PR TITLE
MacOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/.cache
 __pycache__
 *.retry
 pmip
+# IDE:s
+.idea

--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ _Supporting Windows is an best effort (I don't have the possibility to either te
 * `telegraf_win_logfile`: The location to the logfile of Telegraf.
 * `telegraf_win_include`: The directory that will contain all plugin configuration.
 
+## MacOS specific Variables
+
+**NOTE**
+
+_MacOS support is as the Window Support an best effort and not officially supported._
+
+* `telegraf_mac_user`:  Telegraf will run as this user (needed as running things as other users using brew is problematic)
+
 ## Extra information
 
 There are two properties which are similar, but are used differently. Those are:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,3 +82,6 @@ telegraf_win_service_args:
   - -service install
   - -config {{ telegraf_win_install_dir }}\telegraf\telegraf.conf
   - --config-directory {{ telegraf_win_include }}
+
+telegraf_mac_user: user
+telegraf_mac_group: admin

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,3 +20,6 @@
     name: Telegraf
     start_mode: auto
     state: restarted
+
+- name: "Restart MacOS Telegraf"
+  shell: brew services restart telegraf

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,9 @@ galaxy_info:
     - name: Windows
       versions:
         - all
+    - name: MacOS
+      versions:
+        - all
 
   galaxy_tags:
     - monitoring

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@
 galaxy_info:
   author: Werner Dijkerman
   description: Installing and configuring Telegraf
+  role_name: telegraf
   company: myCompany.Dotcom
   license: MIT
   min_ansible_version: 2.4

--- a/tasks/MacOS.yml
+++ b/tasks/MacOS.yml
@@ -1,0 +1,14 @@
+---
+# description: MacOS specific installation
+
+- name: "MacOS | set package name"
+  set_fact:
+    telegraf_agent_package: telegraf
+
+- name: "MacOS | Install Telegraf package"
+  package:
+    name: "{{ telegraf_agent_package }}"
+    state: "{{ telegraf_agent_package_state }}"
+  register: is_telegraf_package_installed
+  until: is_telegraf_package_installed is succeeded
+  notify: "Restart Telegraf"

--- a/tasks/configure_macos.yml
+++ b/tasks/configure_macos.yml
@@ -1,0 +1,128 @@
+---
+# description: Configure telegraf and get all relevent ec2 information
+
+- name: Retrieve ec2 facts
+  ec2_metadata_facts:
+  when:
+    - telegraf_agent_aws_tags
+
+- name: "Add prefix path"
+  set_fact:
+    telegraf_agent_config_path: /usr/local/etc
+  when:
+    - ansible_os_family in ["FreeBSD", "Darwin"]
+
+- name: Retrieve all ec2 tags on the instance
+  ec2_tag:
+    region: '{{ ansible_ec2_placement_region }}'
+    resource: '{{ ansible_ec2_instance_id }}'
+    state: list
+  when:
+    - telegraf_agent_aws_tags
+  register: ec2_tags
+
+- name: "Copy the template for versions < 0.10.0"
+  template:
+    src: etc-opt-telegraf-telegraf.conf.j2
+    dest: /etc/opt/telegraf/telegraf.conf
+    owner: "{{ telegraf_mac_user }}"
+    group: "{{ telegraf_mac_group }}"
+    mode: 0640
+  become: yes
+  when:
+    - telegraf_agent_version is version_compare('0.10.0', '<')
+  notify:
+    - Restart Telegraf
+    - Restart Telegraf container
+
+- name: "Copy the template for versions >= 0.10.0"
+  template:
+    src: telegraf.conf.j2
+    dest: "{{ telegraf_agent_config_path }}/telegraf.conf"
+    owner: "{{ telegraf_mac_user }}"
+    group: "{{ telegraf_mac_group }}"
+    mode: 0640
+  become: yes
+  when:
+    - telegraf_agent_version is version_compare('0.10.0', '>=')
+  notify:
+    - Restart MacOS Telegraf
+    - Restart Telegraf container
+
+- name: "Check if extra plugins directory exists in case of exclusive"
+  stat:
+    path: "{{ telegraf_agent_config_path }}/telegraf.d"
+  register: telegraf_directory
+  when:
+    - telegraf_plugins_extra_exclusive
+
+- name: "Delete telegraf extra plugin path"
+  file:
+    state: absent
+    path: "{{ telegraf_agent_config_path }}/telegraf.d/"
+  when:
+    - telegraf_plugins_extra_exclusive
+    - telegraf_directory.stat.exists
+  become: yes
+  notify:
+    - Restart MacOS Telegraf
+    - Restart Telegraf container
+
+- name: "Create telegraf extra plugin path"
+  file:
+    state: directory
+    path: "{{ telegraf_agent_config_path }}/telegraf.d/"
+    owner: "{{ telegraf_mac_user }}"
+    group: "{{ telegraf_mac_group }}"
+    mode: 0755
+  when:
+    - telegraf_plugins_extra_exclusive
+    - telegraf_directory.stat.exists
+  become: yes
+  notify:
+    - Restart MacOS Telegraf
+    - Restart Telegraf container
+
+- name: "Copy telegraf extra plugins"
+  template:
+    src: "telegraf-extra-plugin.conf.j2"
+    dest: "{{ telegraf_agent_config_path }}/telegraf.d/{{ item.key }}.conf"
+    owner: "{{ telegraf_mac_user }}"
+    group: "{{ telegraf_mac_group }}"
+    mode: 0640
+  with_dict: "{{ telegraf_plugins_extra }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - telegraf_plugins_extra is defined
+    - telegraf_plugins_extra is iterable
+    - item.value.state|default('present') != 'absent'
+  become: yes
+  notify:
+    - Restart MacOS Telegraf
+    - Restart Telegraf container
+
+- name: "Remove telegraf extra plugins"
+  file:
+    path: "{{ telegraf_agent_config_path }}/telegraf.d/{{ item.key }}.conf"
+    state: absent
+  with_dict: "{{ telegraf_plugins_extra }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - telegraf_plugins_extra is defined
+    - telegraf_plugins_extra is iterable
+    - item.value.state|default('present') == 'absent'
+  become: yes
+  notify:
+    - Restart MacOS Telegraf
+    - Restart Telegraf container
+
+- name: "Force restart service after reread config"
+  meta: flush_handlers
+
+- name: "Start Telegraf (If it wasn't running)"
+  shell: brew services start telegraf
+  register: brew_services_start_telegraf
+  changed_when: '"Successfully started `telegraf`" in brew_services_start_telegraf.stdout'
+  when: not telegraf_agent_docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,15 +23,25 @@
   when:
     - ansible_os_family == "FreeBSD" and not telegraf_agent_docker
 
+- name: "Install on MacOS"
+  include_tasks: "MacOS.yml"
+  when:
+    - ansible_os_family == "Darwin" and not telegraf_agent_docker
+
 - include_tasks: "docker.yml"
   when: telegraf_agent_docker
 
 - name: "Configure Telegraf"
   include_tasks: "configure_linux.yml"
   when:
-    - ansible_os_family != "Windows"
+    - ansible_os_family not in ['Windows', 'Darwin']
 
 - name: "Install / Configure telegraf on Windows"
   include_tasks: "configure_windows.yml"
   when:
     - ansible_os_family == "Windows" and not telegraf_agent_docker
+
+- name: "Install / Configure telegraf on MacOS"
+  include_tasks: "configure_macos.yml"
+  when:
+    - ansible_os_family == "Darwin" and not telegraf_agent_docker


### PR DESCRIPTION
**Description of PR**
Provides MacOS support for the role. The brew service system works a bit different than most other linux/bsd service system in that it is only meant to be run as your local user account. I looked into creating a telegraf user and running the service as that but that doesn't seem inline with brew service best practices. On MacOs it is therefore required to specify a `telegraf_mac_user` which should be your main user account.

I also added role_name to the role meta since this is nowadays required to get the role to present correctly on Ansible Galaxy.

**Type of change**
Feature Pull Request
