### PR TITLE
fix debian packagename on state latest

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,10 +1,10 @@
 ---
 
-- name: "Debian | Set name if state == latest"
+- name: "Debian | Set name if state != latest"
   set_fact:
     telegraf_agent_package: telegraf={{ telegraf_agent_version }}-{{ telegraf_agent_version_patch }}
   when:
-    - telegraf_agent_package_state == "latest"
+    - telegraf_agent_package_state != "latest"
 
 - name: "Debian | Set telegraf_agent_package_arch"
   set_fact:


### PR DESCRIPTION
Closes #121

**Description of PR**
Fix the comparison for the debian package state.
It makes no sense to set a specific version number, if the state "latest" was chosen.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
#108 