### PR TITLE
corrected "Example Docker configuration" to make it work by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,8 @@ More information: [https://github.com/influxdata/telegraf/blob/master/docs/FAQ.m
 	telegraf_plugins_default:
 	  - plugin: cpu
 	    config:
-	      - percpu = "true"
+	      - percpu = true
 	  - plugin: disk
-	    tags:
-	      - diskmetrics = "true"
 	    tagpass:
 	      - fstype = [ "ext4", "xfs" ]
 	    tagdrop:


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->
This PR fixes the "Example Docker configuration", because TOML can't parse boolean in quotes, and modern telegraf (1.15.2) doesn't know anything about "diskmetrics"
**Type of change**
<!--- Pick one below and delete the rest: -->
Docs Pull Request

