### PR TITLE
Added property telegraf_agent_docker_image_version for using a specific version of the Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ These properties set in how and what package will be installed.
 * `telegraf_agent_docker_name`: Name of the docker container. Default: `telegraf`
 * `telegraf_agent_docker_network_mode`: Networking mode of the docker container. Default: `bridge`
 * `telegraf_agent_docker_restart_policy`: Docker container restart policy. Default: `unless-stopped`
+* `telegraf_agent_docker_image_version`: The version of the Docker Telegraf image to be used. Default the value contains the value given for `telegraf_agent_version`. Can be set to `latest` to get the actual `latest` tag for the provided Docker image.
 * `telegraf_uid_docker`: Override user id. Default: `995`
 * `telegraf_gid_docker`: Override group id. Default: `998`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ telegraf_agent_docker: False
 telegraf_agent_docker_name: telegraf
 telegraf_agent_docker_network_mode: bridge
 telegraf_agent_docker_restart_policy: unless-stopped
+telegraf_agent_docker_image_version: "{{ telegraf_agent_version }}"
 
 # v0.13 settings (not sure if supported in older version):
 telegraf_agent_collection_jitter: 0

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -38,7 +38,7 @@
 - name: Ensure Telegraf Docker container is running
   docker_container:
     name: "{{ telegraf_agent_docker_name }}"
-    image: "telegraf:{{ telegraf_agent_version }}"
+    image: "telegraf:{{ telegraf_agent_docker_image_version }}"
     state: started
     restart_policy: "{{ telegraf_agent_docker_restart_policy }}"
     command: -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d


### PR DESCRIPTION
Added property telegraf_agent_docker_image_version for using a specific version of the Docker image

**Description of PR**
<!--- Describe what the PR holds -->

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
