### PR TITLE
Fixed issues with Windows paths containing spaces & removed redundant "telegraf" folder in path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,8 +82,8 @@ telegraf_win_logfile: 'C:\\Telegraf\\telegraf.log'
 telegraf_win_include: 'C:\Telegraf\telegraf_agent.d'
 telegraf_win_service_args:
   - -service install
-  - -config {{ telegraf_win_install_dir }}\telegraf\telegraf.conf
-  - --config-directory {{ telegraf_win_include }}
+  - '-config "{{ telegraf_win_install_dir }}\telegraf.conf"'
+  - '--config-directory "{{ telegraf_win_include }}"'
 
 telegraf_mac_user: user
 telegraf_mac_group: admin

--- a/tasks/configure_windows.yml
+++ b/tasks/configure_windows.yml
@@ -30,7 +30,7 @@
 - name: "Windows | Move extracted directory (newer than 1.15)"
   win_copy:
     src: '{{ telegraf_win_install_dir }}\telegraf-{{ telegraf_agent_version }}\'
-    dest: '{{ telegraf_win_install_dir }}\telegraf'
+    dest: '{{ telegraf_win_install_dir }}'
     remote_src: yes
   when: telegraf_agent_version is version('1.15', '>=')
 
@@ -38,14 +38,14 @@
   win_unzip:
     src: '{{ telegraf_win_install_dir }}\telegraf-{{ telegraf_agent_version }}_windows_amd64.zip'
     dest: '{{ telegraf_win_install_dir }}'
-    creates: '{{ telegraf_win_install_dir }}\telegraf\telegraf.exe'
+    creates: '{{ telegraf_win_install_dir }}\telegraf.exe'
     delete_archive: yes
   when: telegraf_agent_version is version('1.15', '<')
 
 - name: "Windows | Configure Telegraf"
   win_template:
     src: telegraf.conf.j2
-    dest: '{{ telegraf_win_install_dir }}\telegraf\telegraf.conf'
+    dest: '{{ telegraf_win_install_dir }}\telegraf.conf'
   notify: "Restart Windows Telegraf"
 
 - name: "Windows | Copy telegraf extra plugins"
@@ -75,7 +75,7 @@
   notify: "Restart Windows Telegraf"
 
 - name: "Windows | Register Service"
-  win_command: '{{ telegraf_win_install_dir }}\telegraf\telegraf.exe {{ telegraf_win_service_args | join(" ") }}'
+  win_command: '"{{ telegraf_win_install_dir }}\telegraf.exe" {{ telegraf_win_service_args | join(" ") }}'
   register: telegraf_windows_install
   args:
     creates: '{{ telegraf_win_install_dir }}\.installed'


### PR DESCRIPTION
**Description of PR**
In the Windows install playbook, paths containing spaces would cause the service start task to fail.  Wrapped the paths in quotes to fix it.  Also the path generated on the host was c:\telegraf\telegraf\telegraf.exe.  Changed to c:\telegraf\telegraf.exe

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request
