### PR TITLE
Add Windows feature of upgrade agents

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 telegraf_enabled: True
 # defaults file for ansible-telegraf
 
-telegraf_agent_version: 1.10.0
+telegraf_agent_version: 1.18.2
 telegraf_agent_version_patch: 1
 telegraf_agent_package: telegraf
 telegraf_agent_package_file_deb: telegraf_{{ telegraf_agent_version }}-{{ telegraf_agent_version_patch }}_{{ telegraf_agent_package_arch }}.deb
@@ -19,6 +19,7 @@ telegraf_agent_flush_jitter: 0
 telegraf_agent_aws_tags: False
 telegraf_agent_aws_tags_prefix: ""
 telegraf_agent_config_path: /etc/telegraf
+telegraf_win_logfile_rotation_max_archives: 3
 
 # Docker specific settings
 telegraf_uid_docker: 998
@@ -82,8 +83,8 @@ telegraf_win_logfile: 'C:\\Telegraf\\telegraf.log'
 telegraf_win_include: 'C:\Telegraf\telegraf_agent.d'
 telegraf_win_service_args:
   - -service install
-  - '-config "{{ telegraf_win_install_dir }}\telegraf.conf"'
-  - '--config-directory "{{ telegraf_win_include }}"'
+  - -config {{ telegraf_win_install_dir }}\telegraf.conf
+  - --config-directory {{ telegraf_win_include }}
 
 telegraf_mac_user: user
 telegraf_mac_group: admin

--- a/tasks/configure_windows.yml
+++ b/tasks/configure_windows.yml
@@ -29,8 +29,8 @@
 
 - name: "Windows | Move extracted directory (newer than 1.15)"
   win_copy:
-    src: '{{ telegraf_win_install_dir }}\telegraf-{{ telegraf_agent_version }}\'
-    dest: '{{ telegraf_win_install_dir }}'
+    src: '{{ telegraf_win_install_dir }}\telegraf-{{ telegraf_agent_version }}\telegraf.exe'
+    dest: '{{ telegraf_win_install_dir }}\telegraf.exe'
     remote_src: yes
   when: telegraf_agent_version is version('1.15', '>=')
 
@@ -40,6 +40,13 @@
     dest: '{{ telegraf_win_install_dir }}'
     creates: '{{ telegraf_win_install_dir }}\telegraf.exe'
     delete_archive: yes
+  when: telegraf_agent_version is version('1.15', '<')
+
+- name: "Windows | Move extracted executable"
+  win_copy:
+    src: '{{ telegraf_win_install_dir }}\telegraf\telegraf.exe'
+    dest: '{{ telegraf_win_install_dir }}\telegraf.exe'
+    remote_src: yes
   when: telegraf_agent_version is version('1.15', '<')
 
 - name: "Windows | Configure Telegraf"
@@ -74,18 +81,31 @@
     - item.value.state|default('present') == 'absent'
   notify: "Restart Windows Telegraf"
 
-- name: "Windows | Register Service"
-  win_command: '"{{ telegraf_win_install_dir }}\telegraf.exe" {{ telegraf_win_service_args | join(" ") }}'
-  register: telegraf_windows_install
-  args:
-    creates: '{{ telegraf_win_install_dir }}\.installed'
+- name: "Windows | Check if Telegraf service is already in place"
+  win_service:
+    name: telegraf
+  register: service_result
+  failed_when: service_result is not defined
 
-- name: "Windows | Create done file so it won't register itself again"
-  win_file:
-    path: '{{ telegraf_win_install_dir }}\.installed'
-    state: touch
+- debug: msg={{ service_result }}
+
+- name: "Windows | Set service startup mode to auto and ensure it is started"
+  win_service:
+    name: Telegraf
+    start_mode: auto
+    state: stopped
   when:
-    - telegraf_windows_install is changed
+    - service_result.exists
+
+- name: "Windows | Unregister Service"
+  win_command: '{{ telegraf_win_install_dir }}\telegraf.exe --service uninstall'
+  register: telegraf_windows_uninstall
+  when:
+    - service_result.exists
+
+- name: "Windows | Register Service"
+  win_command: '{{ telegraf_win_install_dir }}\telegraf.exe {{ telegraf_win_service_args | join(" ") }}'
+  register: telegraf_windows_install
 
 - name: "Windows | Set service startup mode to auto and ensure it is started"
   win_service:

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -30,6 +30,9 @@
 {% if telegraf_agent_version is version_compare('1.1', '>=') %}
 {% if ansible_os_family == "Windows" %}
     logfile = "{{ telegraf_win_logfile }}"
+    logfile_rotation_interval = "{{ telegraf_win_logfile_rotation_interval }}"
+    logfile_rotation_max_size = "{{ telegraf_win_logfile_rotation_max_size }}"
+    logfile_rotation_max_archives = {{ telegraf_win_logfile_rotation_max_archives| int }}
 {% else %}
     logfile = "{{ telegraf_agent_logfile }}"
 {% endif %}


### PR DESCRIPTION
First of all, thanks for the great solution, it saved me a huge headache in the first place. I would appreciate a thorough review as I am just dabbling with Ansible.
The molecule tests run successfully for me.

**Description of PR**
This PR improves the Windows installation by getting rid of the flag file and checking if the service is in place. Also it will compare the version of the desired installation and the current version of the machine. If it does match, it will leave the installation in peace, otherwise it will update the system. The change also contains log rotation for the Windows machines, which was unavaiable at the time of the telegraf version 1.10

**Type of change**
Feature Pull Request

**Fixes an issue**
- It will fix a small issue with the unzipping/installation which can end up in a double "telegraf" path due to the archive having the same folder inside. Changed the path/default for this