### PR TITLE
Add support for Rocky Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ telegraf_yum_baseurl:
   centos: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
   default: "https://repos.influxdata.com/{{ ansible_distribution|lower }}/{{ telegraf_redhat_releasever }}/$basearch/stable"
   redhat: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
+  rocky: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
 telegraf_yum_gpgkey: "https://repos.influxdata.com/influxdb.key"
 
 telegraf_win_install_dir: 'C:\Telegraf'


### PR DESCRIPTION
Rocky Linux is an alternative to CentOS 8

Description of PR
Add support for Rocky Linux 8

Type of change
Updated defaults for `telegraf_yum_baseurl`

Feature Pull Request