### PR TITLE
Add variable for openSUSE RPM repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ _Supporting Windows is an best effort (I don't have the possibility to either te
 * `telegraf_win_logfile`: The location to the logfile of Telegraf.
 * `telegraf_win_include`: The directory that will contain all plugin configuration.
 
+## openSUSE specific Variables
+
+* `telegraf_zypper_baseurl`:  The URL to the openSUSE repository that hosts Telegraf (for example, for openSUSE Leap: "http://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Leap_{{ ansible_distribution_version }}/")
+
 ## MacOS specific Variables
 
 **NOTE**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,6 +79,8 @@ telegraf_yum_baseurl:
   rocky: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
 telegraf_yum_gpgkey: "https://repos.influxdata.com/influxdb.key"
 
+telegraf_zypper_baseurl: "http://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/"
+
 telegraf_win_install_dir: 'C:\Telegraf'
 telegraf_win_logfile: 'C:\\Telegraf\\telegraf.log'
 telegraf_win_include: 'C:\Telegraf\telegraf_agent.d'

--- a/tasks/Suse.yml
+++ b/tasks/Suse.yml
@@ -23,8 +23,8 @@
 
 - name: "Suse | Install basic repo file"
   zypper_repository:
-    repo: "http://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/"
-    name: The Go Programming Language (openSUSE_Factory)
+    repo: "{{ telegraf_zypper_baseurl }}"
+    name: "telegraf"
     state: present
     runrefresh: True
     auto_import_keys: True


### PR DESCRIPTION
**Description of PR**
Removes a hard-coded openSUSE repo URL, allowing for it to be overridden.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
The telegraf RPM in the openSUSE_Factory repo has been broken for a year or more. (There is a missing dependency on glibc for that binary.) This PR provides enough flexibility to override the repo URL. In my case, I have a handful of Leap 15.1 and 15.3. The binaries from those repositories work perfectly for their respective versions.
