### PR TITLE
Adding support for aggregators

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -52,6 +52,13 @@ provisioner:
               name: grok
               config:
                 - patterns = ["invoked oom-killer"]
+        telegraf_aggregators:
+          - aggregator: basicstats
+            config:
+              - drop_original = false
+              - stats = ['mean']
+            tagpass:
+              - cpu = ["cpu-total"]
 
 scenario:
   name: default

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -24,6 +24,7 @@ def test_telegraf_dot_conf(host):
     assert telegraf.contains('[[outputs.influxdb]]')
     assert telegraf.contains('["http://influxdb:8086"]')
     assert telegraf.contains('[[inputs.net]]')
+    assert telegraf.contains('[[aggregators.basicstats]]')
 
 
 def test_telegraf_dot_d_dir(host):

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -118,7 +118,7 @@
 {% endif %}
 
 ###############################################################################
-#                                  PROCESSORS                                    #
+#                                  PROCESSORS                                 #
 ###############################################################################
 
 {% if telegraf_processors is defined and telegraf_processors is iterable %}
@@ -126,6 +126,45 @@
 [[processors.{{ item.processor }}]]
 {% if item.config is defined and item.config is iterable %}
 {% for items in item.config %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.tagpass is defined and item.tagpass is iterable %}
+[processors.{{ item.processor }}.tagpass]
+{% for items in item.tagpass %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.tagdrop is defined and item.tagdrop is iterable %}
+[processors.{{ item.processor }}.tagdrop]
+{% for items in item.tagdrop %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+###############################################################################
+#                                  AGGREGATORS                                #
+###############################################################################
+
+{% if telegraf_aggregators is defined and telegraf_aggregators is iterable %}
+{% for item in telegraf_aggregators %}
+[[aggregators.{{ item.aggregator }}]]
+{% if item.config is defined and item.config is iterable %}
+{% for items in item.config %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.tagpass is defined and item.tagpass is iterable %}
+[aggregators.{{ item.aggregator }}.tagpass]
+{% for items in item.tagpass %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.tagdrop is defined and item.tagdrop is iterable %}
+[aggregators.{{ item.aggregator }}.tagdrop]
+{% for items in item.tagdrop %}
     {{ items }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
**Description of PR**
This PR adds aggregator support and tagpass/tagdrop support for processors and aggregators.

**Type of change**
Feature Pull Request

**Changes**
`templates/telegraf.conf.j2` is updated to have a block for aggregators and tagpass/tagdrop-features. Metric filtering using tagpass/tagdrop is [supported by telegraf](https://docs.influxdata.com/telegraf/v1.21/administration/configuration/#metric-filtering).

A test has been added for the aggregator plugins. Modifying `molecule.yml`-inventory was necessary as aggregators are not enabled by default.