### PR TITLE
Downgrade support

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -96,7 +96,7 @@
   apt:
     deb: "{{ telegraf_agent_package_path }}/{{ telegraf_agent_package }}"
     state: "present"
-    force: yes
+    allow_downgrade: yes
   register: is_telegraf_package_installed
   until: is_telegraf_package_installed is succeeded
   notify: "Restart Telegraf"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -96,6 +96,7 @@
   apt:
     deb: "{{ telegraf_agent_package_path }}/{{ telegraf_agent_package }}"
     state: "present"
+    force: yes
   register: is_telegraf_package_installed
   until: is_telegraf_package_installed is succeeded
   notify: "Restart Telegraf"


### PR DESCRIPTION
**Description of PR**

The downgrade of the online package is not possible now and such attempt results in task failure. `allow_downgrade` setting of the `apt` module allows to perform downgrades.

**Type of change**

Feature Pull Request
