### PR TITLE
Fixed issues with Windows paths containing spaces

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,8 +90,7 @@ telegraf_win_logfile: 'C:\\Telegraf\\telegraf.log'
 telegraf_win_include: 'C:\Telegraf\telegraf_agent.d'
 telegraf_win_service_args:
   - -service install
-  - -config {{ telegraf_win_install_dir }}\telegraf.conf
-  - --config-directory {{ telegraf_win_include }}
-
+  - '-config "{{ telegraf_win_install_dir }}\telegraf.conf"'
+  - '--config-directory "{{ telegraf_win_include }}"'
 telegraf_mac_user: user
 telegraf_mac_group: admin

--- a/tasks/configure_windows.yml
+++ b/tasks/configure_windows.yml
@@ -98,13 +98,13 @@
     - service_result.exists
 
 - name: "Windows | Unregister Service"
-  win_command: '{{ telegraf_win_install_dir }}\telegraf.exe --service uninstall'
+  win_command: '"{{ telegraf_win_install_dir }}\telegraf.exe" --service uninstall'
   register: telegraf_windows_uninstall
   when:
     - service_result.exists
 
 - name: "Windows | Register Service"
-  win_command: '{{ telegraf_win_install_dir }}\telegraf.exe {{ telegraf_win_service_args | join(" ") }}'
+  win_command: '"{{ telegraf_win_install_dir }}\telegraf.exe" {{ telegraf_win_service_args | join(" ") }}'
   register: telegraf_windows_install
 
 - name: "Windows | Set service startup mode to auto and ensure it is started"


### PR DESCRIPTION
**Description of PR**
In the Windows install playbook, paths containing spaces would cause the service install,start und uninstall task to fail. Wrapped the paths in quotes to fix it. Some of this was already done by pull request #144 but got somehow removed or superseeded.

**Type of change**
<!--- Pick one below and delete the rest: -->
Bugfix Pull Request

**Fixes an issue**
No, currently no issue describes this problem
