### PR TITLE
Ensure check-mode works

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,18 +8,22 @@
     enabled: yes
   when: not telegraf_agent_docker
   become: yes
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "Restart Telegraf container"
   docker_container:
     name: "{{ telegraf_agent_docker_name }}"
     restart: True
   when: telegraf_agent_docker
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "Restart Windows Telegraf"
   win_service:
     name: Telegraf
     start_mode: auto
     state: restarted
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "Restart MacOS Telegraf"
   command: brew services restart telegraf
+  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
**Description of PR**
This commit ensures that check-mode works on systems when this role is run without any telegraf being installed.

Before

```
fatal: [host-1]: FAILED! => {"changed": false, "msg": "Could not find the requested service telegraf: host"}
```

After

```
fatal: [host-1]: FAILED! => {"changed": false, "msg": "Could not find the requested service telegraf: host"}
...ignoring
```

**Type of change**

Bugfix Pull Request