### PR TITLE
update influxdata GPG key after rotation

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -39,8 +39,8 @@
 
 - name: "Debian | Download Telegraf apt key"
   apt_key:
-    url: "https://repos.influxdata.com/influxdb.key"
-    id: 2582E0C5
+    url: "https://repos.influxdata.com/influxdata-archive.key"
+    id: 7df8b07e
     state: present
   register: are_telegraf_dependencies_keys_installed
   until: are_telegraf_dependencies_keys_installed is succeeded


### PR DESCRIPTION
**Description of PR**

This PR updates the apt_key to the newly rotated influxdata key. I've tested the change by locally modifying your galaxy role to the new key and then my molecule checks run again.

**Type of change**

Bugfix Pull Request

**Fixes an issue**

This fixes #164
