### PR TITLE
Replace apt_key with get_url

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -38,19 +38,17 @@
   become: yes
 
 - name: "Debian | Download Telegraf apt key"
-  apt_key:
+  when: telegraf_agent_package_method == "repo"
+  ansible.builtin.get_url:
     url: "https://repos.influxdata.com/influxdata-archive.key"
-    id: 7df8b07e
-    state: present
+    dest: /etc/apt/trusted.gpg.d/influxdata-archive.asc
   register: are_telegraf_dependencies_keys_installed
   until: are_telegraf_dependencies_keys_installed is succeeded
   become: yes
-  when:
-    - telegraf_agent_package_method == "repo"
 
 - name: "Debian | Add Telegraf repository (using LSB)"
   apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
+    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.asc] https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
     filename: "telegraf"
     state: present
   become: yes
@@ -61,7 +59,7 @@
 
 - name: "Debian | Add Telegraf repository"
   apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
+    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.asc] https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
     filename: "telegraf"
     state: present
   become: yes


### PR DESCRIPTION
This PR resolves an issue encountered on Debian 11/Ubuntu 22.04 hosts where the apt-key command returns a warning due to deprecation by the OS maintainers, and fails the task as a result.

The most common workaround seems to be placing the key directly into the `trusted.gpg.d` directory and referencing the key path as a `signed-by` parameter in the repo file.  I made this change on my fork and successfully ran the playbook against my Debian 11 hosts.

**Description of PR**
Updating the Debian apt key install process to use the recommended method of placing the key in `trusted.gpg.d` instead of using the deprecated `apt-key` command.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
https://github.com/dj-wasabi/ansible-telegraf/issues/169
