### PR TITLE
Migrate from io to diskio to fix deprecation warning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,7 +55,7 @@ telegraf_plugins_default:
     config:
       - percpu = true
   - plugin: disk
-  - plugin: io
+  - plugin: diskio
   - plugin: mem
   - plugin: net
   - plugin: system


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->

Telegraf throws following deprecation warning:

```
W! DeprecationWarning: Plugin "inputs.io" deprecated since version 0.10.0 and will be removed in 2.0.0: use 'inputs.diskio' instead
```

As far as I can tell this is simple rename and the output of these plugins should not change. I've also tried comparing the output locally and it seems to be the same.

```
# The following command outputs two sets of identical data:
telegraf --test --config telegraf.conf --input-filter io:diskio
```


**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request
