### PR TITLE
replace depracted aws module

### DIFF
--- a/tasks/configure_linux.yml
+++ b/tasks/configure_linux.yml
@@ -13,10 +13,9 @@
     - ansible_os_family == "FreeBSD"
 
 - name: Retrieve all ec2 tags on the instance
-  ec2_tag:
+  amazon.aws.ec2_tag_info:
     region: '{{ ansible_ec2_placement_region }}'
     resource: '{{ ansible_ec2_instance_id }}'
-    state: list
   when:
     - telegraf_agent_aws_tags
   register: ec2_tags

--- a/tasks/configure_macos.yml
+++ b/tasks/configure_macos.yml
@@ -13,10 +13,9 @@
     - ansible_os_family in ["FreeBSD", "Darwin"]
 
 - name: Retrieve all ec2 tags on the instance
-  ec2_tag:
+  amazon.aws.ec2_tag_info:
     region: '{{ ansible_ec2_placement_region }}'
     resource: '{{ ansible_ec2_instance_id }}'
-    state: list
   when:
     - telegraf_agent_aws_tags
   register: ec2_tags


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->
Replace module amazon.aws.ec2_tag in favor to amazon.aws.ec2_tag_info due to deprecation in version 4.0.0

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fix Issues 177
https://github.com/dj-wasabi/ansible-telegraf/issues/177