### PR TITLE
Support for sub_inputs in extra plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Telegraf plugin options:
 * `interval`: How often to gather this metric. Normal plugins use a single global interval, but if one particular plugin should be run less or more often, you can configure that here.
 * `filter.name`: Like when there is an extra filter that needs to be configured, like `grok` for a `logparser` plugin.
 * `filter.config`: The extra configuration for the - in the `filter.name` example - `grok` filter. (See example below)
+* `sub_inputs`: If the input requires other sub inputs, you can add them here (see example below).
 
 An example might look like this:
 
@@ -324,6 +325,30 @@ When you want to make use of the `grok` filter for the logparser:
 			name: grok
 			config:
 			- patterns = ["invoked oom-killer"]
+
+When you want to include a sub inputs with their own configuration:
+```yaml
+sqs:
+  plugin: cloudwatch
+  config:
+    - region = "eu-west-1"
+    - access_key = "foo"
+    - secret_key = "bar"
+    - period = "1m"
+    - delay  = "2m"
+    - interval = "1m"
+    - namespace = "AWS/SQS"
+    - statistic_include = ["average"]
+  sub_inputs:
+    metrics:
+      - names = [
+          "ApproximateAgeOfOldestMessage",
+          "ApproximateNumberOfMessagesVisible",
+        ]
+    metrics.dimensions:
+      - name = "QueueName"
+      - value = "*"
+```
 
 ## Dependencies
 

--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -55,3 +55,11 @@
 {% endfor %}
 {% endfor %}
 {% endif %}
+{% if item.value.sub_inputs is defined and item.value.sub_inputs is iterable %}
+{% for sub_input, config in item.value.sub_inputs.items() %}
+[[inputs.{{ item.value.plugin | default(item.key) }}.{{ sub_input }}]]
+{% for items in config %}
+    {{ items }}
+{% endfor %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
**Description of PR**
There are cases when a sub inputs have to be configured within same file as the main input, for example in [cloudwatch plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/cloudwatch), where you may need to also add `[[inputs.cloudwatch.metrics]]` and `[[inputs.cloudwatch.metrics.dimensions]]` along with the main `[[inputs.cloudwatch]]` input.

**Type of change**
Feature Pull Request


