### PR TITLE
Use `rhel` within yum url for almalinux 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ telegraf_yum_baseurl:
   default: "https://repos.influxdata.com/{{ ansible_distribution|lower }}/{{ telegraf_redhat_releasever }}/$basearch/stable"
   redhat: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
   rocky: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
+  almalinux: "https://repos.influxdata.com/rhel/{{ telegraf_redhat_releasever }}/$basearch/stable"
 telegraf_yum_gpgkey: "https://repos.influxdata.com/influxdata-archive_compat.key"
 
 telegraf_zypper_repos:


### PR DESCRIPTION
**Description of PR**
As already been done for rockylinux this PR adds almalinux to the `defaults/main.yml` to use `rhel` within the yum repository url. Otherwise `almalinux` is inserted into the url and telegraf cannot be installed. 

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request
