### PR TITLE
Debian/Ubuntu: make telegraf_repository_params overridable

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -79,6 +79,7 @@
         - name: "Debian | Set Telegraf apt repository parameters"
           set_fact: 
             telegraf_repository_params: "[signed-by=/usr/share/keyrings/influxdata-archive.asc]"
+          when: telegraf_repository_params is not defined
 
     - name: "Debian | Add Telegraf repository"
       copy:


### PR DESCRIPTION
**Description of PR**
Change the Debian task that sets `telegraf_repository_params` to only run when the var isn't already defined. This lets users pass their own `[signed-by=...]` (e.g. `/etc/apt/keyrings/influxdata-archive.gpg`) without forking. Backwards-compatible; defaults unchanged.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
N/A (enables override so users can work around Jammy keyring verification issues).

**Motivation & Context**
On fresh Ubuntu 22.04.5 VM, APT often requires a dearmored keyring under `/etc/apt/keyrings` for `signed-by`. The role currently hard-codes `telegraf_repository_params` via `set_fact`, which prevents an override `signed-by` to an external to this role managed keyring. Making this `set_fact` conditional restores expected override functionality.

This functionality is used by Galaxy Australia as per PR: [workaround for broken apt-key in dj-wasabi.telegraf #2749] (https://github.com/usegalaxy-au/infrastructure/pull/2749) noting that an indentation error was fixed in tne following PR.
